### PR TITLE
Remove spf13 from archetypes and layouts

### DIFF
--- a/archetypes/project.md
+++ b/archetypes/project.md
@@ -1,13 +1,13 @@
 +++
-Title = "Viper : Go configuration management with Fangs"
-Date = "2014-04-07"
+Title = "Sagittis Enim id Euismod"
+Date = "2016-11-27"
 Description = ""
-Tags = ["Development", "golang"]
+Tags = ["development", "golang"]
 Topics = ["Development", "GoLang"]
-download_url = "http://github.com/spf13/PROJECTNAME"
+download_url = "http://github.com/mdhender/nixon"
 project_description = "DESC"
 project_name = "PROJECTNAME"
 project_url = "URL"
 release_date = "DATE"
-version = "0.2"
+version = "0.0.0"
 +++

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -33,7 +33,7 @@
 <!--Twitter Cards-->
 <meta name="twitter:card" content="summary">
 <!--<meta name="twitter:card" content="summary_large_image">-->
-<meta name="twitter:site" content="@spf13">
+<meta name="twitter:site" content="@nixon.example">
 <meta name="twitter:title" content="{{ .Title }} : nixon.example.com">
 <meta name="twitter:creator" content="@nixon.example">
 <meta name="twitter:description" content="{{ .Description }}">

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -7,7 +7,7 @@
                       <li> <a href="https://twitter.com/intent/tweet?status={{ .Title }}-{{ .Permalink }}" target="_blank" title="Follow me on Twitter" class="twitter"><span class="icon icon-twitter"></span>Twitter</a> </li>
                         <li> <a href="https://www.facebook.com/sharer/sharer.php?u={{ .Permalink }}" target="_blank" title="Join me on Facebook" class="facebook"><span class="icon icon-facebook"></span>Facebook</a> </li>
                         <li> <a href="https://plus.google.com/share?url={{ .Permalink }}" target="_blank" title="Google+" class="googleplus"><span class="icon icon-google-plus"></span>Google+</a> </li>
-                        <li> <a href="http://www.linkedin.com/shareArticle?mini=true&url={{ .Permalink }}&title={{ .Title }}&source=spf13" target="_blank" title="LinkedIn" class="linkedin"><span class="icon icon-linkedin"></span>LinkedIn</a> </li>
+                        <li> <a href="http://www.linkedin.com/shareArticle?mini=true&url={{ .Permalink }}&title={{ .Title }}&source=nixon.example" target="_blank" title="LinkedIn" class="linkedin"><span class="icon icon-linkedin"></span>LinkedIn</a> </li>
                         <li> <a href="http://del.icio.us/post?url={{ .Permalink }}" target="_blank" title="Delicious" class="delicious"><span class="icon icon-delicious"></span>Delicious</a> </li>
                         <li> <a href="http://www.reddit.com/submit?url={{ .Permalink }}" target="_blank" title="Reddit" class="reddit"><span class="icon icon-reddit"></span>Reddit</a> </li>
                         <li> <a href="http://www.stumbleupon.com/submit?url={{ .Permalink }}" target="_blank" title="StumbleUpon" class="stumbleupon"><span class="icon icon-stumbleupon"></span>StumbleUpon</a> </li>

--- a/layouts/project/single.html
+++ b/layouts/project/single.html
@@ -30,7 +30,7 @@
              </a><br>{{end}}
         {{if isset .Params "software_image" }} <meta itemprop="image" content="{{ index .Params "software_iamge" }}">{{end}}
         {{if isset .Params "download_url" }}<meta itemprop="downloadURL" content="{{ index .Params "download_url" }}">{{end}}
-        <meta itemprop="publisher" content="{{ index .Params "publisher" | or "spf13.com" }}">
+        <meta itemprop="publisher" content="{{ index .Params "publisher" | or "nixon.example.com" }}">
         <meta itemprop="softwareApplicationCategory" content="{{ index .Params "software_category" | or "UtilitiesApplication" }}">
         <meta itemprop="operatingSystems" content="{{ index .Params "operating_system" | or "Windows 7 and above, OSX 10.7 and above, linux" }}">
     </div>


### PR DESCRIPTION
Remove remaing spf13 and spf13.com references from
the theme. There are some references that can't be
removed until after I redo the fonts.

Fixes #3