### PR TITLE
Change all RSSlink to RSSLink

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,7 +8,7 @@
     <base href="{{ .Site.BaseURL }}">
     <title>{{ .Site.Title }}</title>
     <link rel="canonical" href="{{ .Permalink }}">
-    <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 
     {{ partial "head_includes.html" . }}
 </head>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,9 +6,9 @@
     {{ partial "meta.html" . }}
 
     <base href="{{ .Site.BaseURL }}">
-    <title> {{ .Title }} - nixon.example.com</title>
+    <title>{{ .Title }} - nixon.example.com</title>
     <link rel="canonical" href="{{ .Permalink }}">
-    {{ if .RSSlink }}<link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Title }}" />{{ end }}
+    {{ if .RSSLink }}<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Title }}" />{{ end }}
 
     {{ partial "head_includes.html" . }}
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />


### PR DESCRIPTION
Modified templates to use {{.RSSLink}} instead of
the deprecated {{.RSSlink}}.

Fixes #7 