### PR TITLE
Update footer to use copyright year from config

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,7 +1,7 @@
 <footer>
   <div>
     <p>
-    &copy; 20116 <span itemprop="author" itemscope itemtype="http://schema.org/Person">
+    &copy; {{.Site.Params.copyright_years}} <span itemprop="author" itemscope itemtype="http://schema.org/Person">
         <span itemprop="name">{{.Site.Params.author}}.</span></span>
     <a href="http://creativecommons.org/licenses/by/3.0/" title="Creative Commons Attribution">Some rights reserved</a>; 
     please attribute properly and link back.


### PR DESCRIPTION
Change the template to use the copyright_year
parameter.

Fixes #16 